### PR TITLE
Update unico-webframe to v3.21.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3",
-    "unico-webframe": "3.21.2"
+    "unico-webframe": "3.21.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.21.4** 📅 Release date: **31/10/2025** 🔗 [Official Release Notes](https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-web/release-notes)

    📝 Release notes:
    - Melhorias internas de produto, ajustes e otimizações de segurança;
    