### PR TITLE
Update unico-webframe to v3.22.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3",
-    "unico-webframe": "3.22.5"
+    "unico-webframe": "3.22.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.22.6** 📅 Release date: **29/01/2026** 🔗 [Official Release Notes](https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-web/release-notes)

    📝 Release notes:
    - Atualização do SDK e server do Liveness com interação;
- Melhoria no timeout das chamadas HTTP;
    