### PR TITLE
Update unico-webframe to v3.23.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3",
-    "unico-webframe": "3.23.7"
+    "unico-webframe": "3.23.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.23.9** 📅 Release date: **20/05/2026** 🔗 [Official Release Notes](https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-web/release-notes)

    📝 Release notes:
    - Melhorias internas de produto, ajustes e otimizações de segurança;
- Personalização da tela de consentimento do SDK.
    